### PR TITLE
Revert "Do not stringify ints in the logs (#14)"

### DIFF
--- a/pkg/events/logs.go
+++ b/pkg/events/logs.go
@@ -38,12 +38,8 @@ func (l Logger) Log(e logs.Entry) {
 	}
 	print("%s", e)
 
-	appKey, _ := e.Tags()[AppKeyTag].(string)
-	participantID, _ := e.Tags()[ParticipantIDTag].(string)
-	spaceID, _ := e.Tags()[SpaceIDTag].(string)
-
 	l.Pusher.NewEvent(logEvent{
-		AppKey:         appKey,
+		AppKey:         e.Tags()[AppKeyTag],
 		AukiSDKType:    l.SDKType,
 		AukiSDKVersion: l.SDKVersionFamily,
 		Data: logEventData{
@@ -52,8 +48,8 @@ func (l Logger) Log(e logs.Entry) {
 		},
 		DeviceOS:      runtime.GOOS,
 		DeviceType:    runtime.GOARCH,
-		ParticipantID: participantID,
-		SpaceID:       spaceID,
+		ParticipantID: e.Tags()[ParticipantIDTag],
+		SpaceID:       e.Tags()[SpaceIDTag],
 		Event:         "log",
 		Timestamp:     e.Time().UnixMilli(),
 	})

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -160,15 +160,15 @@ func TestEntryGetError(t *testing.T) {
 
 func TestEntryTags(t *testing.T) {
 	e := WithTag("hello", "max")
-	require.Equal(t, map[string]any{"hello": "max"}, e.Tags())
+	require.Equal(t, map[string]string{"hello": "max"}, e.Tags())
 }
 
-func TestNormalizeTag(t *testing.T) {
+func TestToString(t *testing.T) {
 	SetInlineEncoder()
 
-	testValues := []struct {
+	utests := []struct {
 		in  interface{}
-		out any
+		out string
 	}{
 		{
 			in:  "hello",
@@ -184,51 +184,51 @@ func TestNormalizeTag(t *testing.T) {
 		},
 		{
 			in:  -42,
-			out: -42,
+			out: "-42",
 		},
 		{
 			in:  int64(-42),
-			out: int64(-42),
+			out: "-42",
 		},
 		{
 			in:  int32(-42),
-			out: int32(-42),
+			out: "-42",
 		},
 		{
 			in:  int16(-42),
-			out: int16(-42),
+			out: "-42",
 		},
 		{
 			in:  int8(-42),
-			out: int8(-42),
+			out: "-42",
 		},
 		{
 			in:  uint(84),
-			out: uint(84),
+			out: "84",
 		},
 		{
 			in:  uint64(84),
-			out: uint64(84),
+			out: "84",
 		},
 		{
 			in:  uint32(84),
-			out: uint32(84),
+			out: "84",
 		},
 		{
 			in:  uint16(84),
-			out: uint16(84),
+			out: "84",
 		},
 		{
 			in:  uint8(84),
-			out: uint8(84),
+			out: "84",
 		},
 		{
 			in:  42.42,
-			out: 42.42,
+			out: "42.42",
 		},
 		{
 			in:  float32(42.42),
-			out: float32(42.42),
+			out: "42.42",
 		},
 		{
 			in:  true,
@@ -248,9 +248,9 @@ func TestNormalizeTag(t *testing.T) {
 		},
 	}
 
-	for _, u := range testValues {
+	for _, u := range utests {
 		t.Run(reflect.TypeOf(u.in).String(), func(t *testing.T) {
-			require.Equal(t, u.out, normalizeTag(u.in))
+			require.Equal(t, u.out, toString(u.in))
 		})
 	}
 }


### PR DESCRIPTION
This reverts commit 065272a69c8e113bc8d57c4369047a76b9de9bf3.

@omusil24 we have some crash on Hagall related to this change. Need to revert this for now. Let's investigate later what it the problem.