### PR TITLE
remove event requeue logic

### DIFF
--- a/pkg/events/pusher_test.go
+++ b/pkg/events/pusher_test.go
@@ -84,27 +84,6 @@ func TestPusher(t *testing.T) {
 	})
 }
 
-func TestPusherFlushRequeue(t *testing.T) {
-	initLogs(t)
-
-	count := 0
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		count++
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer s.Close()
-
-	l := Pusher{
-		Endpoint: s.URL,
-	}
-	l.Start()
-
-	l.flush([]Event{42}, requeueOnErr)
-	l.Close()
-
-	require.Equal(t, 2, count)
-}
-
 func initLogs(t *testing.T) {
 	logs.Encoder = func(v any) ([]byte, error) {
 		return json.MarshalIndent(v, "", "  ")


### PR DESCRIPTION
## Summary

- events are not re-queued anymore when an error occurs. This is to prevent OOM errors when the event log endpoint is down.