### PR TITLE
fix: explicitly set which repository to release to

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,4 +144,5 @@ jobs:
         run: |
           gh release upload \
             "${{ github.ref_name }}" \
-            dist/${APP}-${{ github.ref_name }}-*/*
+            dist/${APP}-${{ github.ref_name }}-*/* \
+            --repo "${{ github.repository }}"


### PR DESCRIPTION
Needed since we didn't check out the repository before running the release upload command.